### PR TITLE
Fix kernel build instructions

### DIFF
--- a/XACGamepad/Drivers/README.md
+++ b/XACGamepad/Drivers/README.md
@@ -14,7 +14,7 @@ Be sure to install the dependencies and toolchains. Choose whether
 cross-compiling or compiling on a Raspberry Pi.
 
 ```bash
-git clone --depth=1 --branch rpi-5.10.y https://github.com/raspberrypi/linux
+git clone https://github.com/raspberrypi/linux
 cd linux
 git checkout raspberrypi-kernel_1.20210201-1
 ```


### PR DESCRIPTION
The whole repo must be cloned. Using "--depth=1" does not work.

I helped someone setup a Pi to do kernel builds and found my instructions do not work. :(